### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,24 @@ project(qupled LANGUAGES CXX)
 # Set output directory for the project
 set(QUPLED_OUTPUT_DIR ${CMAKE_BINARY_DIR}/qupled)
 
+find_package(Boost COMPONENTS python3 numpy3 REQUIRED)
+
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
+
+find_package(MPI REQUIRED)
+
+if(MPI_FOUND)
+  include_directories(${MPI_INCLUDE_DIRS})
+endif()
+
+find_package(GSL REQUIRED)
+
+if(GSL_FOUND)
+  include_directories(${GSL_INCLUDE_DIRS})
+endif()
+
 # Add subdirectories
 add_subdirectory(python)
 add_subdirectory(src)


### PR DESCRIPTION
On my local operating system, i.e., 

Ubuntu 22.04.4 LTS 

with 

gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
cmake version 3.25.2

I need to adjust your CMakeLists.txt as cmake was not able to resolve the dependencies.